### PR TITLE
Make Fees#usd_volume optional

### DIFF
--- a/src/private_client/private_client.rs
+++ b/src/private_client/private_client.rs
@@ -1235,7 +1235,7 @@ pub struct Fill {
 pub struct Fees {
     maker_fee_rate: String,
     taker_fee_rate: String,
-    usd_volume: String,
+    usd_volume: Option<String>,
 }
 
 /// A structure represents a single profile


### PR DESCRIPTION
This struct can fail to deserialize if the account has no volume; this
field will be null.