### PR TITLE
Change order amounts, etc. type to String

### DIFF
--- a/src/private_client/order.rs
+++ b/src/private_client/order.rs
@@ -4,19 +4,19 @@ use serde::Serialize;
 #[derive(Serialize, Debug)]
 pub struct Order {
     r#type: String,
-    size: Option<f64>,
-    price: Option<f64>,
+    size: Option<String>,
+    price: Option<String>,
     side: OrderSide,
     client_oid: Option<String>,
     self_trade_prevention: Option<SelfTradePrevention>,
     time_in_force: Option<TimeInForce>,
     cancel_after: Option<CancelAfter>,
     post_only: Option<bool>,
-    funds: Option<f64>,
+    funds: Option<String>,
     product_id: String,
     stp: Option<String>,
     stop: Option<OrderStop>,
-    stop_price: Option<f64>,
+    stop_price: Option<String>,
 }
 
 /// A `OrderBuilder` should be used to create a `Order` with  custom configuration.
@@ -30,7 +30,7 @@ impl Order {
         OrderBuilder {
             r#type: "market".to_string(),
             size: match size_or_funds {
-                SizeOrFunds::Size(n) => Some(n),
+                SizeOrFunds::Size(ref n) => Some(n.to_owned()),
                 _ => None,
             },
             price: None,
@@ -41,7 +41,7 @@ impl Order {
             cancel_after: None,
             post_only: None,
             funds: match size_or_funds {
-                SizeOrFunds::Funds(n) => Some(n),
+                SizeOrFunds::Funds(ref n) => Some(n.to_owned()),
                 _ => None,
             },
             product_id: product_id.to_string(),
@@ -55,13 +55,13 @@ impl Order {
     pub fn limit_builder(
         side: OrderSide,
         product_id: &str,
-        price: f64,
-        size: f64,
+        price: &str,
+        size: &str,
     ) -> impl LimitOptions + SharedOptions {
         OrderBuilder {
             r#type: "limit".to_string(),
-            size: Some(size),
-            price: Some(price),
+            size: Some(size.to_owned()),
+            price: Some(price.to_owned()),
             side: side,
             client_oid: None,
             self_trade_prevention: None,
@@ -80,15 +80,15 @@ impl Order {
     pub fn stop_builder(
         side: OrderSide,
         product_id: &str,
-        price: f64,
-        size: f64,
-        stop_price: f64,
+        price: &str,
+        size: String,
+        stop_price: &str,
         stop: OrderStop,
     ) -> impl SharedOptions {
         OrderBuilder {
             r#type: "limit".to_string(),
             size: Some(size),
-            price: Some(price),
+            price: Some(price.to_owned()),
             side: side,
             client_oid: None,
             self_trade_prevention: None,
@@ -99,7 +99,7 @@ impl Order {
             product_id: product_id.to_string(),
             stp: None,
             stop: Some(stop),
-            stop_price: Some(stop_price),
+            stop_price: Some(stop_price.to_owned()),
         }
     }
 }
@@ -109,19 +109,19 @@ impl Order {
 /// Confiuguration parameters details can be found [here](https://docs.pro.coinbase.com/#orders)
 pub struct OrderBuilder {
     r#type: String,
-    size: Option<f64>,
-    price: Option<f64>,
+    size: Option<String>,
+    price: Option<String>,
     side: OrderSide,
     client_oid: Option<String>,
     self_trade_prevention: Option<SelfTradePrevention>,
     time_in_force: Option<TimeInForce>,
     cancel_after: Option<CancelAfter>,
     post_only: Option<bool>,
-    funds: Option<f64>,
+    funds: Option<String>,
     product_id: String,
     stp: Option<String>,
     stop: Option<OrderStop>,
-    stop_price: Option<f64>,
+    stop_price: Option<String>,
 }
 
 impl OrderBuilder {
@@ -134,7 +134,7 @@ impl OrderBuilder {
         Self {
             r#type: "market".to_string(),
             size: match size_or_funds {
-                SizeOrFunds::Size(n) => Some(n),
+                SizeOrFunds::Size(ref n) => Some(n.to_owned()),
                 _ => None,
             },
             price: None,
@@ -145,7 +145,7 @@ impl OrderBuilder {
             cancel_after: None,
             post_only: None,
             funds: match size_or_funds {
-                SizeOrFunds::Funds(n) => Some(n),
+                SizeOrFunds::Funds(ref n) => Some(n.to_owned()),
                 _ => None,
             },
             product_id: product_id.to_string(),
@@ -159,13 +159,13 @@ impl OrderBuilder {
     pub fn limit(
         side: OrderSide,
         product_id: &str,
-        price: f64,
-        size: f64,
+        price: &str,
+        size: &str,
     ) -> impl LimitOptions + SharedOptions {
         Self {
             r#type: "limit".to_string(),
-            size: Some(size),
-            price: Some(price),
+            size: Some(size.to_owned()),
+            price: Some(price.to_owned()),
             side: side,
             client_oid: None,
             self_trade_prevention: None,
@@ -184,15 +184,15 @@ impl OrderBuilder {
     pub fn stop(
         side: OrderSide,
         product_id: &str,
-        price: f64,
-        size: f64,
-        stop_price: f64,
+        price: &str,
+        size: &str,
+        stop_price: &str,
         stop: OrderStop,
     ) -> impl SharedOptions {
         Self {
             r#type: "limit".to_string(),
-            size: Some(size),
-            price: Some(price),
+            size: Some(size.to_owned()),
+            price: Some(price.to_owned()),
             side: side,
             client_oid: None,
             self_trade_prevention: None,
@@ -203,7 +203,7 @@ impl OrderBuilder {
             product_id: product_id.to_string(),
             stp: None,
             stop: Some(stop),
-            stop_price: Some(stop_price),
+            stop_price: Some(stop_price.to_owned()),
         }
     }
 }
@@ -296,10 +296,10 @@ pub enum OrderStop {
 }
 
 /// Size or Funds of Currency
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum SizeOrFunds {
-    Size(f64),
-    Funds(f64),
+    Size(String),
+    Funds(String),
 }
 
 // Time in force policies provide guarantees about the lifetime of an `Order`
@@ -406,8 +406,8 @@ impl serde::Serialize for SizeOrFunds {
         S: serde::ser::Serializer,
     {
         match *self {
-            Self::Size(size) => serializer.serialize_f64(size),
-            Self::Funds(funds) => serializer.serialize_f64(funds),
+            Self::Size(ref size) => serializer.serialize_str(size),
+            Self::Funds(ref funds) => serializer.serialize_str(funds),
         }
     }
 }

--- a/src/private_client/private_client.rs
+++ b/src/private_client/private_client.rs
@@ -614,7 +614,7 @@ impl PrivateClient {
     /// ~~~~
     pub async fn deposit_funds(
         &self,
-        amount: f64,
+        amount: &str,
         currency: &str,
         payment_method_id: &str,
     ) -> Result<DepositInfo, Error> {

--- a/tests/private_client.rs
+++ b/tests/private_client.rs
@@ -26,21 +26,27 @@ async fn test_get_account() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_place_order_market_funds() {
-    let order = OrderBuilder::market(OrderSide::Buy, "BTC-USD", SizeOrFunds::Funds(10.00)).build();
+    let order = OrderBuilder::market(
+        OrderSide::Buy,
+        "BTC-USD",
+        SizeOrFunds::Funds("10.00".to_owned()),
+    )
+    .build();
     let client = create_client();
     let _res = client.place_order(order).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_place_order_market_size() {
-    let order = OrderBuilder::market(OrderSide::Buy, "ADA", SizeOrFunds::Size(5.00)).build();
+    let order =
+        OrderBuilder::market(OrderSide::Buy, "ADA", SizeOrFunds::Size("5.00".to_owned())).build();
     let client = create_client();
     let _res = client.place_order(order).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_place_order_limit() {
-    let order = Order::limit_builder(OrderSide::Buy, "BTC-USD", 36000.0, 1.0).build();
+    let order = Order::limit_builder(OrderSide::Buy, "BTC-USD", "36000.0", "1.0").build();
     let client = create_client();
     let _res = client.place_order(order).await.unwrap();
 }
@@ -50,9 +56,9 @@ async fn test_place_order_stop() {
     let order = OrderBuilder::stop(
         OrderSide::Buy,
         "BTC-USD",
-        36000.0,
-        1.0,
-        37000.0,
+        "36000.0",
+        "1.0",
+        "37000.0",
         OrderStop::Loss,
     )
     .build();
@@ -62,7 +68,7 @@ async fn test_place_order_stop() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_cancel_order() {
-    let order = OrderBuilder::limit(OrderSide::Buy, "BTC-USD", 33000.0, 1.0).build();
+    let order = OrderBuilder::limit(OrderSide::Buy, "BTC-USD", "33000.0", "1.0").build();
     let client = create_client();
     let order_to_cancel_id = client.place_order(order).await.unwrap();
     let _canceled_order_id = client.cancel_order(&order_to_cancel_id).await.unwrap();
@@ -90,7 +96,7 @@ async fn test_get_orders() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_get_order() {
-    let order = OrderBuilder::limit(OrderSide::Buy, "BTC-USD", 36000.0, 1.0).build();
+    let order = OrderBuilder::limit(OrderSide::Buy, "BTC-USD", "36000.0", "1.0").build();
     let client = create_client();
     let order_id = client.place_order(order).await.unwrap();
     let _order = client.get_order(&order_id).await.unwrap();
@@ -173,7 +179,7 @@ async fn test_get_coinbase_accounts() {
 async fn test_deposit_funds() {
     let client = create_client();
     let _deposit = client
-        .deposit_funds(10.00, "USD", "9da3e279-20a1-57e4-95f8-52ec41041999")
+        .deposit_funds("10.00", "USD", "9da3e279-20a1-57e4-95f8-52ec41041999")
         .await
         .unwrap();
 }


### PR DESCRIPTION
The Coinbase API will reject orders that have numbers with too much
precision, and using Strings allows for convenient formatting of numbers
to a specific precision.